### PR TITLE
Added option to run parallel workers in independent working directories

### DIFF
--- a/src/main/java/com/lmax/ant/paralleljunit/ParallelJUnitTask.java
+++ b/src/main/java/com/lmax/ant/paralleljunit/ParallelJUnitTask.java
@@ -79,6 +79,8 @@ public class ParallelJUnitTask extends Task implements ParallelJUnitTaskConfig
     private boolean shuffle = false;
     private final int availableProcessors = Runtime.getRuntime().availableProcessors();
     private int threads = availableProcessors;
+    private boolean dirPerWorker = false;
+    private String workerDirPrefix = "parallel-junit-";
 
     private CommandlineJava commandLine = new CommandlineJava();
     private Environment environment = new Environment();
@@ -206,6 +208,16 @@ public class ParallelJUnitTask extends Task implements ParallelJUnitTaskConfig
     public void setNewEnvironment(final boolean newEnvironment)
     {
         this.newEnvironment = newEnvironment;
+    }
+
+    public void setDirPerWorker(boolean dirPerWorker)
+    {
+        this.dirPerWorker = dirPerWorker;
+    }
+
+    public void setWorkerDirPrefix(String workerDirPrefix)
+    {
+        this.workerDirPrefix = workerDirPrefix;
     }
 
     public void setShowOutput(final boolean showOutput)
@@ -355,6 +367,16 @@ public class ParallelJUnitTask extends Task implements ParallelJUnitTaskConfig
     public boolean isNewEnvironment()
     {
         return newEnvironment;
+    }
+
+    public boolean isDirPerWorker()
+    {
+        return dirPerWorker;
+    }
+
+    public String getWorkerDirPrefix()
+    {
+        return workerDirPrefix;
     }
 
     public Map<String, String> getEnvironment()

--- a/src/main/java/com/lmax/ant/paralleljunit/ParallelJUnitTaskConfig.java
+++ b/src/main/java/com/lmax/ant/paralleljunit/ParallelJUnitTaskConfig.java
@@ -44,4 +44,8 @@ public interface ParallelJUnitTaskConfig
     ProjectComponent getProjectComponent();
 
     int getThreads();
+
+    boolean isDirPerWorker();
+
+    String getWorkerDirPrefix();
 }

--- a/src/main/java/com/lmax/ant/paralleljunit/remote/controller/RemoteTestRunnerProcessFactory.java
+++ b/src/main/java/com/lmax/ant/paralleljunit/remote/controller/RemoteTestRunnerProcessFactory.java
@@ -42,9 +42,21 @@ public class RemoteTestRunnerProcessFactory
 
         final DelegatingProcessBuilder processBuilder = processBuilderFactory.createProcessBuilder(jvmCommand);
 
-        final File workingDirectory = config.getDirectory();
+        File workingDirectory = config.getDirectory();
+        if (config.isDirPerWorker())
+        {
+            File baseDirectory = workingDirectory != null ? workingDirectory : new File(System.getProperty("user.dir"));
+            workingDirectory = new File(baseDirectory, config.getWorkerDirPrefix() + workerId);
+        }
         if (workingDirectory != null)
         {
+            if (!workingDirectory.exists())
+            {
+                if (!workingDirectory.mkdirs())
+                {
+                    throw new BuildException("Failed to create worker directory: " + workingDirectory.getPath());
+                }
+            }
             processBuilder.directory(workingDirectory);
         }
 


### PR DESCRIPTION
... to allow tests to be parallelized even if they create files on the file system. We are useing parallel-junit on a large, existing code base. Ideally, unit tests shouldn't be creating files in the cwd, but unfortunately, we have quite a few which do. In order to give us time to fix these tests, I added this option. It seems like something that would be useful for other teams with large numbers of tests which do this.
